### PR TITLE
Fix module loading by building JS into public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ node_modules
 dist
 .DS_Store
 
+public/*.js
+public/core/
+public/content/
+

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 ```bash
 npm install
 npm test
+npm run build
 ```
 
 `npm test` запускает проверку TypeScript-компиляции.
+
+`npm run build` компилирует исходники в папку `public`, после чего можно открыть `public/index.html` в браузере или раздавать её через статический сервер.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "test": "tsc --noEmit"
+    "test": "tsc --noEmit",
+    "build": "tsc && cp -r content public/content"
   },
   "devDependencies": {
     "typescript": "^5.3.3"

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,6 @@
   <title>Сердца на грани чудес</title>
 </head>
 <body>
-  <script type="module" src="../dist/src/main.js"></script>
+  <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { runEpisode, Episode } from './core/engine/episodeRunner.js';
 
 (async () => {
-  // resolve JSON relative to this compiled module (works when files находятся в dist/)
+  // resolve JSON relative to this compiled module (works when files находятся в public/)
   const epUrl = new URL('../../content/episodes/ep1.json', import.meta.url).href;
   const res = await fetch(epUrl);
   if (!res.ok) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "strict": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "outDir": "dist"
+    "outDir": "public"
   },
   "include": ["src", "content"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- output TypeScript compilation to `public` and copy content files
- reference built `main.js` in `public/index.html`
- document build step and ignore generated files

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8629c30888328838eb584193e2ac1