### PR TITLE
feat: interactive engine with music node and DOM updates

### DIFF
--- a/content/episodes/ep1.json
+++ b/content/episodes/ep1.json
@@ -3,7 +3,7 @@
   "title": "Пропавший том",
   "start": "A0",
   "nodes": {
-    "A0": { "type": "set", "vars": {"music":"calm_theme_1"}, "next":"A1" },
+    "A0": { "type": "music", "music":"calm_theme_1", "next":"A1" },
     "A1": { "type": "bg", "bg":"bg_library_evening", "next":"A2" },
     "A2": { "type": "say", "who":"MC", "text":"Вечер в библиотеке всегда звучит шёпотом страниц. И сегодня — слишком тихо.", "next":"A3" },
     "A3": { "type": "sprite", "who":"Kiana", "sprite":"kiana_happy", "pos":"right", "next":"A4" },

--- a/public/styles.css
+++ b/public/styles.css
@@ -10,4 +10,43 @@ body {
   background: #fff;
   border: 1px solid #ccc;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  position: relative;
+  overflow: hidden;
+  min-height: 400px;
+}
+
+#game .bg,
+#game .sprites {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+#game .bg {
+  background-size: cover;
+  background-position: center;
+  z-index: 0;
+}
+
+#game .sprites {
+  z-index: 1;
+}
+
+#game .sprites img {
+  position: absolute;
+  bottom: 0;
+  max-height: 100%;
+}
+
+#game .log,
+#game .choices {
+  position: relative;
+  z-index: 10;
+}
+
+#game .choices button {
+  display: block;
+  margin: 0.25rem 0;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,5 +12,5 @@ import { runEpisode, Episode } from './core/engine/episodeRunner.js';
   if (!container) {
     throw new Error('Game container element not found');
   }
-  runEpisode(ep as Episode, container);
+  await runEpisode(ep as Episode, container);
 })();


### PR DESCRIPTION
## Summary
- extend episode runner with `music` node and interactive choice UI
- render backgrounds, sprites, music and sfx via DOM & HTMLAudio
- make runner asynchronous and await user input

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a87f170474832889356eb9dc4518c7